### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,5 +1,6 @@
 {
     "name"        : "GGE",
+    "license"     : "Artistic-2.0",
     "version"     : "*",
     "description" : "Glacial Grammar Engine -- a Perl 6 grammar engine written in Perl 6",
     "provides"    : {


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license